### PR TITLE
fix leaderboard scroll bars appearing everywhere

### DIFF
--- a/components/dashboard/overview/Leaderboard.tsx
+++ b/components/dashboard/overview/Leaderboard.tsx
@@ -50,7 +50,7 @@ export default function Leaderboard() {
                 <td className="px-6 py-4 text-center">{index + 1}</td>
                 <th
                   scope="row"
-                  className="pr-6 py-4 min-w-[200px] max-w-[200px] overflow-scroll font-medium text-gray-900 whitespace-nowrap dark:text-white"
+                  className="pr-6 py-4 min-w-[200px] max-w-[200px] overflow-x-auto font-medium text-gray-900 whitespace-nowrap dark:text-white"
                 >
                   {key.name}{' '}
                 </th>


### PR DESCRIPTION
Maybe you made it overflow-scroll for a reason so def change it back if i'm wrong, but on my desktop, there are scroll bars surrounding everyone's name.
If overflow-scroll was used for mobile purposes, then we could just use tailwind's responsive sizes? idk maybe i'm wrong.