### PR TITLE
Made information show only for that event

### DIFF
--- a/components/dashboard/overview/Leaderboard.tsx
+++ b/components/dashboard/overview/Leaderboard.tsx
@@ -11,7 +11,7 @@ interface FrequencyItem {
 }
 
 export default function Leaderboard() {
-  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
+  const { activeEvent } = useEventStore((state) => state);
   const { data, error, isLoading } = useSWR(
     activeEvent?.id
       ? `/api/analytics/leaderboard?eventId=${activeEvent.id}`

--- a/components/dashboard/overview/Leaderboard.tsx
+++ b/components/dashboard/overview/Leaderboard.tsx
@@ -14,7 +14,7 @@ export default function Leaderboard() {
   const { activeEvent, setActiveEvent } = useEventStore((state) => state);
   const { data, error, isLoading } = useSWR(
     activeEvent?.id
-      ? `/api/analytics/leaderboard?eventId=${activeEvent?.id}`
+      ? `/api/analytics/leaderboard?eventId=${activeEvent.id}`
       : '/api/analytics/leaderboard',
     fetcher,
     {}

--- a/components/dashboard/overview/Leaderboard.tsx
+++ b/components/dashboard/overview/Leaderboard.tsx
@@ -3,6 +3,7 @@ import { fetcher } from '../../../lib/common';
 import useSWR from 'swr';
 import Link from 'next/link';
 
+import useEventStore from '@/stores/useEventStore';
 interface FrequencyItem {
   name: string;
   email: string;
@@ -10,8 +11,11 @@ interface FrequencyItem {
 }
 
 export default function Leaderboard() {
+  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
   const { data, error, isLoading } = useSWR(
-    '/api/analytics/leaderboard',
+    activeEvent?.id
+      ? `/api/analytics/leaderboard?eventId=${activeEvent?.id}`
+      : '/api/analytics/leaderboard',
     fetcher,
     {}
   );

--- a/components/dashboard/overview/MiniIncomingTickets.tsx
+++ b/components/dashboard/overview/MiniIncomingTickets.tsx
@@ -41,7 +41,7 @@ export function MiniIncomingTickets() {
   const { activeEvent, setActiveEvent } = useEventStore((state) => state);
   const { data, error, isLoading } = useSWR(
     activeEvent?.id
-      ? `/api/analytics/tickets/incoming?eventId=${activeEvent?.id}`
+      ? `/api/analytics/tickets/incoming?eventId=${activeEvent.id}`
       : '/api/analytics/tickets/incoming',
     fetcher,
     {}
@@ -102,10 +102,15 @@ export function MiniIncomingTickets() {
 }
 
 export function MiniResolvedTickets({ id }: { id?: string }) {
+  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
   const { data, error, isLoading } = useSWR(
     id
-      ? `/api/analytics/tickets/mentorresolved?email=${id}`
-      : '/api/tickets/resolved',
+      ? activeEvent?.id
+        ? `/api/analytics/tickets/mentorresolved?email=${id}&eventId=${activeEvent.id}`
+        : `/api/analytics/tickets/mentorresolved?email=${id}`
+      : activeEvent?.id
+        ? `/api/tickets/resolved?eventId=${activeEvent.id}`
+        : '/api/tickets/resolved',
     fetcher,
     {}
   );

--- a/components/dashboard/overview/MiniIncomingTickets.tsx
+++ b/components/dashboard/overview/MiniIncomingTickets.tsx
@@ -38,7 +38,7 @@ export function createDataPoints(data: [Ticket], hoursAgo = 6) {
 }
 
 export function MiniIncomingTickets() {
-  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
+  const { activeEvent } = useEventStore((state) => state);
   const { data, error, isLoading } = useSWR(
     activeEvent?.id
       ? `/api/analytics/tickets/incoming?eventId=${activeEvent.id}`
@@ -102,7 +102,7 @@ export function MiniIncomingTickets() {
 }
 
 export function MiniResolvedTickets({ id }: { id?: string }) {
-  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
+  const { activeEvent } = useEventStore((state) => state);
   const { data, error, isLoading } = useSWR(
     id
       ? activeEvent?.id

--- a/components/dashboard/overview/MiniIncomingTickets.tsx
+++ b/components/dashboard/overview/MiniIncomingTickets.tsx
@@ -5,6 +5,8 @@ import useSWR from 'swr';
 import { Ticket } from '@prisma/client';
 import { Skeleton } from '@chakra-ui/react';
 
+import useEventStore from '@/stores/useEventStore';
+
 function emptyPoints(count: number) {
   return Array.from({ length: count }, () => ({ Tickets: 0 }));
 }
@@ -36,8 +38,11 @@ export function createDataPoints(data: [Ticket], hoursAgo = 6) {
 }
 
 export function MiniIncomingTickets() {
+  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
   const { data, error, isLoading } = useSWR(
-    '/api/analytics/tickets/incoming',
+    activeEvent?.id
+      ? `/api/analytics/tickets/incoming?eventId=${activeEvent?.id}`
+      : '/api/analytics/tickets/incoming',
     fetcher,
     {}
   );

--- a/components/dashboard/overview/Topics.tsx
+++ b/components/dashboard/overview/Topics.tsx
@@ -4,7 +4,7 @@ import useSWR from 'swr';
 import useEventStore from '@/stores/useEventStore';
 
 export default function Topics({ email }: { email?: string | undefined }) {
-  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
+  const { activeEvent } = useEventStore((state) => state);
   const { data, error, isLoading } = useSWR(
     email
       ? activeEvent?.id

--- a/components/dashboard/overview/Topics.tsx
+++ b/components/dashboard/overview/Topics.tsx
@@ -1,10 +1,18 @@
 import React from 'react';
 import { fetcher } from '../../../lib/common';
 import useSWR from 'swr';
+import useEventStore from '@/stores/useEventStore';
 
 export default function Topics({ email }: { email?: string | undefined }) {
+  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
   const { data, error, isLoading } = useSWR(
-    email ? `/api/analytics/tickets/mentortopics?email=${email}` : '/api/analytics/tickets/topics',
+    email
+      ? activeEvent?.id
+        ? `/api/analytics/tickets/mentortopics?email=${email}&eventId=${activeEvent.id}`
+        : `/api/analytics/tickets/mentortopics?email=${email}`
+      : activeEvent?.id
+        ? `/api/analytics/tickets/topics?eventId=${activeEvent.id}`
+        : '/api/analytics/tickets/topics',
     fetcher,
     {}
   );
@@ -23,15 +31,17 @@ export default function Topics({ email }: { email?: string | undefined }) {
 
   return (
     <div className="flex gap-2 flex-wrap lg:w-[500px] max-h-[200px] overflow-y-scroll">
-      {topics.filter((topic) => topic[1] > 1).map((topic) => (
-        <div
-          key={topic[0]}
-          className="flex gap-1 border-2 rounded-md p-1 bg-gray-200"
-        >
-          <p className="font-semibold">{topic[0]}</p>
-          <p>{topic[1]}</p>
-        </div>
-      ))}
+      {topics
+        .filter((topic) => topic[1] > 1)
+        .map((topic) => (
+          <div
+            key={topic[0]}
+            className="flex gap-1 border-2 rounded-md p-1 bg-gray-200"
+          >
+            <p className="font-semibold">{topic[0]}</p>
+            <p>{topic[1]}</p>
+          </div>
+        ))}
     </div>
   );
 }

--- a/components/dashboard/users/MiniTotalTicketsCreated.tsx
+++ b/components/dashboard/users/MiniTotalTicketsCreated.tsx
@@ -1,10 +1,26 @@
 import React from 'react';
 import { fetcher } from '../../../lib/common';
 import useSWR from 'swr';
-import { Skeleton, Stat, StatHelpText, StatLabel, StatNumber } from '@chakra-ui/react';
+import {
+  Skeleton,
+  Stat,
+  StatHelpText,
+  StatLabel,
+  StatNumber,
+} from '@chakra-ui/react';
 
-export function MiniTotalTicketsCreated({ userId }: { userId: string | undefined }) {
-  const { data, error, isLoading } = useSWR(`/api/analytics/tickets/usercreated?userId=${userId}`,
+import useEventStore from '@/stores/useEventStore';
+
+export function MiniTotalTicketsCreated({
+  userId,
+}: {
+  userId: string | undefined;
+}) {
+  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
+  const { data, error, isLoading } = useSWR(
+    activeEvent?.id
+      ? `/api/analytics/tickets/usercreated?userId=${userId}&eventId=${activeEvent.id}`
+      : `/api/analytics/tickets/usercreated?userId=${userId}`,
     fetcher,
     {}
   );

--- a/components/dashboard/users/MiniTotalTicketsCreated.tsx
+++ b/components/dashboard/users/MiniTotalTicketsCreated.tsx
@@ -16,7 +16,7 @@ export function MiniTotalTicketsCreated({
 }: {
   userId: string | undefined;
 }) {
-  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
+  const { activeEvent } = useEventStore((state) => state);
   const { data, error, isLoading } = useSWR(
     activeEvent?.id
       ? `/api/analytics/tickets/usercreated?userId=${userId}&eventId=${activeEvent.id}`

--- a/components/dashboard/users/MiniTotalTicketsResolved.tsx
+++ b/components/dashboard/users/MiniTotalTicketsResolved.tsx
@@ -9,9 +9,14 @@ import {
   StatNumber,
 } from '@chakra-ui/react';
 
+import useEventStore from '@/stores/useEventStore';
+
 export function MiniTotalTicketsResolved({ id }: { id: string }) {
+  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
   const { data, error, isLoading } = useSWR(
-    `/api/analytics/tickets/mentorresolved?id=${id}`,
+    activeEvent?.id
+      ? `/api/analytics/tickets/mentorresolved?id=${id}&eventId=${activeEvent.id}`
+      : `/api/analytics/tickets/mentorresolved?id=${id}`,
     fetcher,
     {}
   );

--- a/components/dashboard/users/MiniTotalTicketsResolved.tsx
+++ b/components/dashboard/users/MiniTotalTicketsResolved.tsx
@@ -12,7 +12,7 @@ import {
 import useEventStore from '@/stores/useEventStore';
 
 export function MiniTotalTicketsResolved({ id }: { id: string }) {
-  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
+  const { activeEvent } = useEventStore((state) => state);
   const { data, error, isLoading } = useSWR(
     activeEvent?.id
       ? `/api/analytics/tickets/mentorresolved?id=${id}&eventId=${activeEvent.id}`

--- a/pages/api/analytics/leaderboard.ts
+++ b/pages/api/analytics/leaderboard.ts
@@ -20,9 +20,12 @@ export default async function handler(
     return;
   }
 
+  const eventId = req.query.eventId;
+
   const resolvedTickets = await prisma.ticket.findMany({
     where: {
       isResolved: true,
+      eventId: eventId as string,
     },
     include: { claimant: true },
     orderBy: {

--- a/pages/api/analytics/tickets/incoming.ts
+++ b/pages/api/analytics/tickets/incoming.ts
@@ -15,7 +15,12 @@ export default async function handler(
     return;
   }
 
+  const eventId = req.query.eventId;
+
   const tickets = await prisma.ticket.findMany({
+    where: {
+      eventId: eventId as string,
+    },
     orderBy: {
       publishTime: 'desc',
     },

--- a/pages/api/analytics/tickets/mentorresolved.ts
+++ b/pages/api/analytics/tickets/mentorresolved.ts
@@ -16,10 +16,12 @@ export default async function handler(
   }
 
   const { id } = req.query;
+  const eventId = req.query.eventId;
 
   const tickets = await prisma.ticket.findMany({
     where: {
       claimantId: id as string,
+      eventId: eventId as string,
       isResolved: true,
     },
     orderBy: {

--- a/pages/api/analytics/tickets/mentortopics.ts
+++ b/pages/api/analytics/tickets/mentortopics.ts
@@ -14,12 +14,14 @@ export default async function handler(
     return;
   }
   const { email } = req.query;
+  const eventId = req.query.eventId;
 
   const resolvedTickets = await prisma.ticket.findMany({
     where: {
       claimant: {
         email: email as string,
       },
+      eventId: eventId as string,
       isResolved: true,
     },
     include: {

--- a/pages/api/analytics/tickets/topics.ts
+++ b/pages/api/analytics/tickets/topics.ts
@@ -14,7 +14,12 @@ export default async function handler(
     return;
   }
 
+  const eventId = req.query.eventId;
+
   const totalTickets = await prisma.ticket.findMany({
+    where: {
+      eventId: eventId as string,
+    },
     orderBy: {
       publishTime: 'desc',
     },

--- a/pages/api/analytics/tickets/usercreated.ts
+++ b/pages/api/analytics/tickets/usercreated.ts
@@ -15,10 +15,12 @@ export default async function handler(
   }
 
   const { userId } = req.query;
+  const eventId = req.query.eventId;
 
   const tickets = await prisma.ticket.findMany({
     where: {
       authorId: userId as string,
+      eventId: eventId as string,
     },
     orderBy: {
       publishTime: 'desc',

--- a/pages/api/tickets/resolved.ts
+++ b/pages/api/tickets/resolved.ts
@@ -16,12 +16,12 @@ export default async function handler(
     return;
   }
 
-  const activeEvent = await getActiveEvent();
+  const eventId = req.query.eventId;
 
   const tickets = await prisma.ticket.findMany({
     where: {
       isResolved: true,
-      eventId: activeEvent?.id,
+      eventId: eventId as string,
     },
     orderBy: {
       publishTime: 'desc',

--- a/pages/dashboard/overview.tsx
+++ b/pages/dashboard/overview.tsx
@@ -24,7 +24,7 @@ const Overview: NextPageWithLayout = () => {
         <p className="text-3xl font-bold mb-4">Leaderboard</p>
         <Leaderboard />
       </div>
-      <div className="mt-8">
+      <div className="mt-8 mb-8">
         <p className="text-3xl font-bold mb-4">Topics</p>
         <Topics />
       </div>

--- a/pages/dashboard/users/[email].tsx
+++ b/pages/dashboard/users/[email].tsx
@@ -18,7 +18,7 @@ import { UserWithRoles } from '@/components/common/types';
 import useEventStore from '@/stores/useEventStore';
 
 const UserInfo: NextPageWithLayout = () => {
-  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
+  const { activeEvent } = useEventStore((state) => state);
   const router = useRouter();
   const { data, error, isLoading } = useSWR(
     `/api/users/lookup?email=${router.query.email}`,

--- a/pages/dashboard/users/[email].tsx
+++ b/pages/dashboard/users/[email].tsx
@@ -14,8 +14,11 @@ import { fetcher, Nullable } from '../../../lib/common';
 import prisma from '../../../lib/prisma';
 import authOptions from '../../api/auth/[...nextauth]';
 import { NextPageWithLayout } from '../../_app';
+import { UserWithRoles } from '@/components/common/types';
+import useEventStore from '@/stores/useEventStore';
 
 const UserInfo: NextPageWithLayout = () => {
+  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
   const router = useRouter();
   const { data, error, isLoading } = useSWR(
     `/api/users/lookup?email=${router.query.email}`,
@@ -23,7 +26,7 @@ const UserInfo: NextPageWithLayout = () => {
     {}
   );
 
-  const user: User = data?.user;
+  const user: UserWithRoles = data?.user;
 
   if (isLoading || error || !user) {
     return <></>;
@@ -36,7 +39,9 @@ const UserInfo: NextPageWithLayout = () => {
         <p>{user.email}</p>
         <div className="flex flex-row gap-2">
           {user.admin && <Tag>Admin</Tag>}
-          {user.mentor && <Tag>Mentor</Tag>}
+          {user.roles.some(
+            (role) => role.mentor && role.eventId === activeEvent?.id
+          ) && <Tag>Mentor</Tag>}
         </div>
       </div>
       <div className="flex flex-col gap-2 mt-8">

--- a/pages/dashboard/users/index.tsx
+++ b/pages/dashboard/users/index.tsx
@@ -26,7 +26,7 @@ const Users: NextPageWithLayout = () => {
   const [showOnlyMentors, setShowOnlyMentors] = useState<boolean>(false);
   const [showOnlyAdmins, setShowOnlyAdmins] = useState<boolean>(false);
 
-  const { activeEvent, setActiveEvent } = useEventStore((state) => state);
+  const { activeEvent } = useEventStore((state) => state);
 
   const handleSearchQueryChange = (
     event: React.ChangeEvent<HTMLInputElement>


### PR DESCRIPTION
Potential problems
- erorr handling might be poor
- on /dashboard/users, was unable to filter who the actual users were at each event (no info provided on that)

Fixed
- /dashboard/overview
* incoming tickets updated per event (untested)
* resolved tickets updated per event (untested)
* leaderboard updated per event (tested)
* topics updated per event (tested)
- /dashboard/users
* mentor count per event (tested)
* mentor filter button per event (tested)
* mentor checkmarks per event (tested)
- /dashboard/users/email@gmail.com
* mentor tags appear per event (tested)
* tickets created per event (tested)
* tickets resolved per event (tested)
* tickets resolved recently per event (untested)
* topics per event (tested)