### PR TITLE
Replace ticket polling with a server-sent events stream

### DIFF
--- a/components/home/Submit.tsx
+++ b/components/home/Submit.tsx
@@ -5,6 +5,7 @@ import axios from 'axios';
 import React, { useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import useSWR, { useSWRConfig } from 'swr';
+import { useTicketStream } from '@/hooks/use-ticket-stream';
 import { z } from 'zod';
 import {
   fetcher,
@@ -37,8 +38,10 @@ const FormSchema = z.object({
 type IFormInput = z.infer<typeof FormSchema>;
 
 export const Submit = () => {
+  const connected = useTicketStream();
   const { data, error, isLoading } = useSWR('/api/users/me', fetcher, {
-    refreshInterval: 5000,
+    // The stream is the fast path; polling only covers a dropped connection.
+    refreshInterval: connected ? 0 : 5000,
   });
   const { mutate } = useSWRConfig();
   const [submitLoading, setSubmitLoading] = useState(false);

--- a/components/tickets/TicketStream.tsx
+++ b/components/tickets/TicketStream.tsx
@@ -1,4 +1,6 @@
 import type { Ticket } from '@/generated/prisma/client';
+import { useTicketStream } from '@/hooks/use-ticket-stream';
+import { MdLink, MdLinkOff } from 'react-icons/md';
 import useSWR from 'swr';
 import { fetcher, getTimeDifferenceString } from '../../lib/common';
 import { TextCard } from '../common/TextCard';
@@ -24,13 +26,20 @@ const Ticket = ({ ticket, filter }: { ticket: Ticket; filter: string }) => {
   );
 };
 
-export const TicketStream = ({ filter }: { filter: string }) => {
+const Tickets = ({
+  filter,
+  connected,
+}: {
+  filter: string;
+  connected: boolean;
+}) => {
   const {
     data: ticketsData,
     error: ticketError,
     isLoading: isTicketLoading,
   } = useSWR(`/api/tickets/${filter || 'active'}`, fetcher, {
-    refreshInterval: 5000,
+    // The stream is the fast path; polling only covers a dropped connection.
+    refreshInterval: connected ? 0 : 5000,
   });
 
   if (isTicketLoading) {
@@ -48,4 +57,29 @@ export const TicketStream = ({ filter }: { filter: string }) => {
   return ticketsData.tickets.map((ticket: Ticket, index: number) => (
     <Ticket ticket={ticket} key={index} filter={filter}></Ticket>
   ));
+};
+
+export const TicketStream = ({ filter }: { filter: string }) => {
+  const connected = useTicketStream();
+
+  return (
+    <>
+      <div className="flex justify-end pt-3 -mb-4">
+        {connected ? (
+          <MdLink
+            className="text-green-500"
+            title="Live updates connected"
+            aria-label="Live updates connected"
+          />
+        ) : (
+          <MdLinkOff
+            className="text-gray-400"
+            title="Live updates disconnected, falling back to refresh"
+            aria-label="Live updates disconnected"
+          />
+        )}
+      </div>
+      <Tickets filter={filter} connected={connected} />
+    </>
+  );
 };

--- a/hooks/use-ticket-stream.ts
+++ b/hooks/use-ticket-stream.ts
@@ -1,9 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useSWRConfig } from 'swr';
 
+// The server closes each stream before the serverless duration limit, so a
+// reconnect every ~50s is normal. Ride it out before reporting a drop.
+const DROP_GRACE_MS = 5000;
+
 // Subscribes to /api/tickets/stream and revalidates the ticket-related SWR
-// caches whenever the server reports a change. Returns the connection state so
-// callers can fall back to polling while disconnected.
+// caches whenever the server reports a change. Returns whether events are
+// actually arriving, so callers can fall back to polling while they are not.
 // ponytail: one EventSource per calling component. Only one such component is
 // mounted per page today; add a provider if that stops being true.
 export const useTicketStream = () => {
@@ -12,10 +16,14 @@ export const useTicketStream = () => {
 
   useEffect(() => {
     const source = new EventSource('/api/tickets/stream');
+    let dropTimer: number | undefined;
 
-    source.onopen = () => setConnected(true);
-    source.onerror = () => setConnected(false);
+    // Deliberately not keyed off `onopen`: the server opens the stream before
+    // it knows whether the database answers, so only a delivered event proves
+    // the connection is live.
     source.onmessage = () => {
+      window.clearTimeout(dropTimer);
+      dropTimer = undefined;
       setConnected(true);
       mutate(
         (key) =>
@@ -24,7 +32,21 @@ export const useTicketStream = () => {
       );
     };
 
-    return () => source.close();
+    source.onerror = () => {
+      // Never restart the timer: a stream that keeps failing retries every 3s,
+      // and rescheduling on each retry would starve the timeout forever. The
+      // clock runs from the first failure until an event actually arrives.
+      if (dropTimer !== undefined) {
+        return;
+      }
+
+      dropTimer = window.setTimeout(() => setConnected(false), DROP_GRACE_MS);
+    };
+
+    return () => {
+      window.clearTimeout(dropTimer);
+      source.close();
+    };
   }, [mutate]);
 
   return connected;

--- a/hooks/use-ticket-stream.ts
+++ b/hooks/use-ticket-stream.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { useSWRConfig } from 'swr';
+
+// Subscribes to /api/tickets/stream and revalidates the ticket-related SWR
+// caches whenever the server reports a change. Returns the connection state so
+// callers can fall back to polling while disconnected.
+// ponytail: one EventSource per calling component. Only one such component is
+// mounted per page today; add a provider if that stops being true.
+export const useTicketStream = () => {
+  const { mutate } = useSWRConfig();
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    const source = new EventSource('/api/tickets/stream');
+
+    source.onopen = () => setConnected(true);
+    source.onerror = () => setConnected(false);
+    source.onmessage = () => {
+      setConnected(true);
+      mutate(
+        (key) =>
+          typeof key === 'string' &&
+          (key.startsWith('/api/tickets') || key === '/api/users/me')
+      );
+    };
+
+    return () => source.close();
+  }, [mutate]);
+
+  return connected;
+};

--- a/hooks/use-ticket-stream.ts
+++ b/hooks/use-ticket-stream.ts
@@ -1,53 +1,137 @@
-import { useEffect, useState } from 'react';
-import { useSWRConfig } from 'swr';
+import { useSyncExternalStore } from 'react';
+import { mutate } from 'swr';
+
+const STREAM_URL = '/api/tickets/stream';
 
 // The server closes each stream before the serverless duration limit, so a
 // reconnect every ~50s is normal. Ride it out before reporting a drop.
 const DROP_GRACE_MS = 5000;
 
-// Subscribes to /api/tickets/stream and revalidates the ticket-related SWR
-// caches whenever the server reports a change. Returns whether events are
-// actually arriving, so callers can fall back to polling while they are not.
-// ponytail: one EventSource per calling component. Only one such component is
-// mounted per page today; add a provider if that stops being true.
-export const useTicketStream = () => {
-  const { mutate } = useSWRConfig();
-  const [connected, setConnected] = useState(false);
+// The server emits a change or a heartbeat every 2s. A socket that stays open
+// while the other end has gone quiet (sleeping laptop, dropped NAT mapping,
+// wedged database) is the failure that silently stops updates, so treat four
+// missed beats as dead rather than trusting the connection.
+const HEARTBEAT_TIMEOUT_MS = 8000;
 
-  useEffect(() => {
-    const source = new EventSource('/api/tickets/stream');
-    let dropTimer: number | undefined;
+// One stream per tab, shared by every component that asks for it, kept in a
+// module-level store so `useSyncExternalStore` can hand out a tear-free
+// snapshot and the connection count never depends on the render tree.
+const listeners = new Set<() => void>();
 
-    // Deliberately not keyed off `onopen`: the server opens the stream before
-    // it knows whether the database answers, so only a delivered event proves
-    // the connection is live.
-    source.onmessage = () => {
-      window.clearTimeout(dropTimer);
-      dropTimer = undefined;
-      setConnected(true);
-      mutate(
-        (key) =>
-          typeof key === 'string' &&
-          (key.startsWith('/api/tickets') || key === '/api/users/me')
-      );
-    };
+let source: EventSource | null = null;
+let subscribers = 0;
+let connected = false;
+let dropTimer: number | undefined;
+let heartbeatTimer: number | undefined;
 
-    source.onerror = () => {
-      // Never restart the timer: a stream that keeps failing retries every 3s,
-      // and rescheduling on each retry would starve the timeout forever. The
-      // clock runs from the first failure until an event actually arrives.
-      if (dropTimer !== undefined) {
-        return;
-      }
+const publish = (next: boolean) => {
+  if (connected === next) {
+    return;
+  }
 
-      dropTimer = window.setTimeout(() => setConnected(false), DROP_GRACE_MS);
-    };
-
-    return () => {
-      window.clearTimeout(dropTimer);
-      source.close();
-    };
-  }, [mutate]);
-
-  return connected;
+  connected = next;
+  listeners.forEach((notify) => notify());
 };
+
+const closeStream = () => {
+  window.clearTimeout(dropTimer);
+  window.clearTimeout(heartbeatTimer);
+  dropTimer = undefined;
+  heartbeatTimer = undefined;
+  source?.close();
+  source = null;
+  publish(false);
+};
+
+const openStream = () => {
+  // A hidden tab has nothing to render and would still hold the server in its
+  // polling loop, so it stays closed until the tab comes back.
+  if (source || document.visibilityState === 'hidden') {
+    return;
+  }
+
+  const stream = new EventSource(STREAM_URL);
+
+  const awaitNextBeat = () => {
+    window.clearTimeout(heartbeatTimer);
+    heartbeatTimer = window.setTimeout(() => {
+      // Already late, so no grace period here: drop to polling and start over
+      // on a fresh connection.
+      closeStream();
+      openStream();
+    }, HEARTBEAT_TIMEOUT_MS);
+  };
+
+  // Deliberately not keyed off `onopen`: the server opens the stream before it
+  // knows whether the database answers, so only a delivered event proves the
+  // connection is live.
+  stream.onmessage = () => {
+    window.clearTimeout(dropTimer);
+    dropTimer = undefined;
+    awaitNextBeat();
+    publish(true);
+    mutate(
+      (key) =>
+        typeof key === 'string' &&
+        (key.startsWith('/api/tickets') || key === '/api/users/me')
+    );
+  };
+
+  // Heartbeats prove liveness without touching any cache.
+  stream.addEventListener('ping', awaitNextBeat);
+
+  stream.onerror = () => {
+    // Never restart the timer: a stream that keeps failing retries every 3s,
+    // and rescheduling on each retry would starve the timeout forever. The
+    // clock runs from the first failure until an event actually arrives.
+    if (dropTimer !== undefined) {
+      return;
+    }
+
+    dropTimer = window.setTimeout(() => publish(false), DROP_GRACE_MS);
+  };
+
+  source = stream;
+  awaitNextBeat();
+};
+
+const handleVisibilityChange = () => {
+  if (document.visibilityState === 'hidden') {
+    closeStream();
+    return;
+  }
+
+  // Every fresh connection is answered with the current ticket fingerprint, so
+  // reopening also catches up on whatever changed while the tab was hidden.
+  openStream();
+};
+
+const subscribe = (onStoreChange: () => void) => {
+  listeners.add(onStoreChange);
+
+  if (++subscribers === 1) {
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    openStream();
+  }
+
+  return () => {
+    listeners.delete(onStoreChange);
+
+    if (--subscribers === 0) {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      closeStream();
+    }
+  };
+};
+
+/**
+ * Subscribes to the ticket stream and revalidates the ticket-related SWR caches
+ * whenever the server reports a change. Returns whether events are actually
+ * arriving, so callers can fall back to polling while they are not.
+ */
+export const useTicketStream = () =>
+  useSyncExternalStore(
+    subscribe,
+    () => connected,
+    () => false
+  );

--- a/pages/api/tickets/stream.ts
+++ b/pages/api/tickets/stream.ts
@@ -18,7 +18,10 @@ const POLL_MS = 2000;
 
 // Vercel kills long functions; close cleanly and let EventSource reconnect.
 const MAX_STREAM_MS = 50_000;
-export const maxDuration = 60;
+
+// Pages Router functions read the duration off the config export, not a
+// named `maxDuration` export.
+export const config = { maxDuration: 60 };
 
 export default async function handler(
   req: NextApiRequest,
@@ -43,8 +46,13 @@ export default async function handler(
   res.write('retry: 3000\n\n');
 
   let closed = false;
-  req.on('close', () => {
+  let wake: (() => void) | undefined;
+
+  // `res` is the connection-bound stream; `req` completes as soon as the
+  // client finished sending the (empty) request body.
+  res.on('close', () => {
     closed = true;
+    wake?.();
   });
 
   const deadline = Date.now() + MAX_STREAM_MS;
@@ -69,13 +77,18 @@ export default async function handler(
         res.write(`data: ${current}\n\n`);
       }
     } catch (error) {
+      // End the stream instead of writing a comment: an SSE comment is
+      // invisible to EventSource, so the client would keep believing it is
+      // connected and would never fall back to polling.
       console.error('Error reading ticket state for SSE:', error);
-      res.write(': error\n\n');
+      break;
     }
 
     const { promise, resolve } = Promise.withResolvers<void>();
-    setTimeout(resolve, POLL_MS);
+    wake = resolve;
+    const timer = setTimeout(resolve, POLL_MS);
     await promise;
+    clearTimeout(timer);
   }
 
   res.end();

--- a/pages/api/tickets/stream.ts
+++ b/pages/api/tickets/stream.ts
@@ -1,12 +1,12 @@
+import { setTimeout as sleep } from 'node:timers/promises';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getToken } from 'next-auth/jwt';
-import { getActiveEvent } from '../../../lib/eventHelper';
 import prisma from '../../../lib/prisma';
 
 /*
- * GET Request: Server-Sent Events stream that pings clients whenever the
- * ticket table changes. No ticket data is sent; clients revalidate the
- * existing ticket endpoints, which already handle auth and filtering.
+ * GET Request: Server-Sent Events stream that notifies clients whenever the
+ * ticket table changes. No ticket data is sent; clients revalidate the existing
+ * ticket endpoints, which already handle auth and filtering.
  */
 
 // ponytail: server-side fingerprint poll instead of a pub/sub bus. This app
@@ -19,22 +19,31 @@ const POLL_MS = 2000;
 // Vercel kills long functions; close cleanly and let EventSource reconnect.
 const MAX_STREAM_MS = 50_000;
 
-// Pages Router functions read the duration off the config export, not a
-// named `maxDuration` export.
+// A killed database can leave the socket half-open, so the driver waits on a
+// query that will never answer. Bound every tick: a stalled stream that stays
+// open is worse than a closed one, because the client keeps trusting it.
+const QUERY_TIMEOUT_MS = 5000;
+
+// Pages Router functions read the duration off the config export, not a named
+// `maxDuration` export.
 export const config = { maxDuration: 60 };
+
+type Fingerprint = { tickets: number; changed: Date | null };
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
   if (req.method !== 'GET') {
-    return res.status(405).end();
+    res.status(405).end();
+    return;
   }
 
   const token = await getToken({ req });
 
   if (!token) {
-    return res.status(401).end();
+    res.status(401).end();
+    return;
   }
 
   res.writeHead(200, {
@@ -45,50 +54,76 @@ export default async function handler(
   });
   res.write('retry: 3000\n\n');
 
-  let closed = false;
-  let wake: (() => void) | undefined;
-
-  // `res` is the connection-bound stream; `req` completes as soon as the
-  // client finished sending the (empty) request body.
-  res.on('close', () => {
-    closed = true;
-    wake?.();
-  });
+  // `res` is the connection-bound stream; `req` completes as soon as the client
+  // finished sending the (empty) request body. Without the error listener, a
+  // write to an already-destroyed socket would surface as an unhandled error
+  // event and take the server process down.
+  const disconnected = new AbortController();
+  res.on('close', () => disconnected.abort());
+  res.on('error', () => disconnected.abort());
 
   const deadline = Date.now() + MAX_STREAM_MS;
   let last = '';
 
-  while (!closed && Date.now() < deadline) {
-    try {
-      const activeEvent = await getActiveEvent();
-      const { _count, _max } = await prisma.ticket.aggregate({
-        where: { eventId: activeEvent?.id },
-        _count: { _all: true },
-        _max: { updatedTime: true },
-      });
+  while (!disconnected.signal.aborted && Date.now() < deadline) {
+    const tick = new AbortController();
 
-      // Count catches inserts/deletes, max(updatedTime) catches edits.
-      const current = `${_count._all}:${_max.updatedTime?.getTime() ?? 0}`;
+    try {
+      // One statement, so the active event and its tickets come from the same
+      // snapshot and each tick costs a single round trip. The `NOT EXISTS`
+      // branch mirrors /api/tickets/*, which fall back to every ticket when no
+      // event is active.
+      const query = prisma.$queryRaw<Fingerprint[]>`
+        WITH active AS (
+          SELECT id FROM "Event"
+          WHERE "isActive"
+          ORDER BY "createdTime" DESC
+          LIMIT 1
+        )
+        SELECT count(*)::int AS tickets, max("updatedTime") AS changed
+        FROM "Ticket"
+        WHERE "eventId" = (SELECT id FROM active)
+           OR NOT EXISTS (SELECT 1 FROM active)
+      `;
+
+      const [fingerprint] = await Promise.race([
+        query,
+        sleep(QUERY_TIMEOUT_MS, undefined, { signal: tick.signal }).then<never>(
+          () => {
+            throw new Error('Timed out reading ticket state');
+          }
+        ),
+      ]);
+
+      // Count catches inserts and deletes, max(updatedTime) catches edits.
+      const current = `${fingerprint.tickets}:${
+        fingerprint.changed?.getTime() ?? 0
+      }`;
 
       if (current === last) {
-        res.write(': ping\n\n');
+        // A named event, not an SSE comment: the client has to be able to see
+        // the heartbeat to tell a live stream from a silently stalled one.
+        res.write('event: ping\ndata: 0\n\n');
       } else {
         last = current;
         res.write(`data: ${current}\n\n`);
       }
     } catch (error) {
-      // End the stream instead of writing a comment: an SSE comment is
-      // invisible to EventSource, so the client would keep believing it is
-      // connected and would never fall back to polling.
+      // Close the stream rather than keep it open in a broken state: a client
+      // that still holds an open connection trusts it and stops polling.
       console.error('Error reading ticket state for SSE:', error);
       break;
+    } finally {
+      // Cancel the losing timer so it cannot outlive its tick.
+      tick.abort();
     }
 
-    const { promise, resolve } = Promise.withResolvers<void>();
-    wake = resolve;
-    const timer = setTimeout(resolve, POLL_MS);
-    await promise;
-    clearTimeout(timer);
+    try {
+      await sleep(POLL_MS, undefined, { signal: disconnected.signal });
+    } catch {
+      // The client went away mid-tick.
+      break;
+    }
   }
 
   res.end();

--- a/pages/api/tickets/stream.ts
+++ b/pages/api/tickets/stream.ts
@@ -1,6 +1,7 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getToken } from 'next-auth/jwt';
+import { getActiveEvent } from '../../../lib/eventHelper';
 import prisma from '../../../lib/prisma';
 
 /*
@@ -19,60 +20,33 @@ const POLL_MS = 2000;
 // Vercel kills long functions; close cleanly and let EventSource reconnect.
 const MAX_STREAM_MS = 50_000;
 
-// Postgres cancels the read itself, so a blocked database returns a real error
-// and frees the pooled connection instead of leaving a statement behind. Sent
-// per transaction with SET LOCAL rather than as a pool-wide startup parameter:
-// the blast radius stays on this endpoint and it survives a transaction-pooling
-// proxy, which can reject unknown startup parameters.
-const QUERY_TIMEOUT_MS = 4000;
-
-// Prisma aborts a transaction on its own clock too, and that path reports an
-// expired transaction without Postgres ever cancelling the statement. Keep it
-// strictly slower so the database is always the one that gives up first.
-const TRANSACTION_TIMEOUT_MS = 8000;
-
 // Pages Router functions read the duration off the config export, not a named
 // `maxDuration` export.
 export const config = { maxDuration: 60 };
 
-type Fingerprint = { tickets: number; changed: Date | null };
-
-// Every stream on this instance shares one in-flight read. Ten mentors cost one
-// query per tick instead of ten, and an unreachable database can only ever hold
-// a single query, so reconnects cannot pile them up in the pool.
-let inflight: Promise<Fingerprint> | null = null;
+// Every stream on this instance shares one in-flight read: ten mentors cost one
+// query per tick instead of ten, and a wedged database can only ever hold a
+// single hung query, so reconnects cannot pile them up in the pool. The client
+// heartbeat watchdog drops the UI to polling within 8s of a stall.
+let inflight: Promise<string> | null = null;
 
 const readFingerprint = () => {
-  inflight ??= prisma
-    .$transaction(
-      async (tx) => {
-        await tx.$executeRawUnsafe(
-          `SET LOCAL statement_timeout = ${QUERY_TIMEOUT_MS}`
-        );
+  inflight ??= (async () => {
+    const activeEvent = await getActiveEvent();
 
-        // One statement, so the active event and its tickets come from the same
-        // snapshot. The `NOT EXISTS` branch mirrors /api/tickets/*, which fall
-        // back to every ticket when no event is active.
-        const [fingerprint] = await tx.$queryRaw<Fingerprint[]>`
-          WITH active AS (
-            SELECT id FROM "Event"
-            WHERE "isActive"
-            ORDER BY "createdTime" DESC
-            LIMIT 1
-          )
-          SELECT count(*)::int AS tickets, max("updatedTime") AS changed
-          FROM "Ticket"
-          WHERE "eventId" = (SELECT id FROM active)
-             OR NOT EXISTS (SELECT 1 FROM active)
-        `;
-
-        return fingerprint;
-      },
-      { timeout: TRANSACTION_TIMEOUT_MS }
-    )
-    .finally(() => {
-      inflight = null;
+    // `eventId: undefined` drops the filter, so with no active event this
+    // counts every ticket, exactly like the /api/tickets/* list endpoints.
+    const { _count, _max } = await prisma.ticket.aggregate({
+      where: { eventId: activeEvent?.id },
+      _count: { _all: true },
+      _max: { updatedTime: true },
     });
+
+    // tickets count catches inserts and deletes, max(updatedTime) edits.
+    return `${_count._all}:${_max.updatedTime?.getTime() ?? 0}`;
+  })().finally(() => {
+    inflight = null;
+  });
 
   return inflight;
 };
@@ -114,12 +88,7 @@ export default async function handler(
 
   while (!disconnected.signal.aborted && Date.now() < deadline) {
     try {
-      const fingerprint = await readFingerprint();
-
-      // Count catches inserts and deletes, max(updatedTime) catches edits.
-      const current = `${fingerprint.tickets}:${
-        fingerprint.changed?.getTime() ?? 0
-      }`;
+      const current = await readFingerprint();
 
       if (current === last) {
         // A named event, not an SSE comment: the client has to be able to see
@@ -131,9 +100,7 @@ export default async function handler(
       }
     } catch (error) {
       // Close the stream rather than keep it open in a broken state: a client
-      // that still holds an open connection trusts it and stops polling. The
-      // client reconnects, and its heartbeat watchdog covers the window where
-      // an unreachable database answers neither us nor Postgres' own timeout.
+      // that still holds an open connection trusts it and stops polling.
       console.error('Error reading ticket state for SSE:', error);
       break;
     }

--- a/pages/api/tickets/stream.ts
+++ b/pages/api/tickets/stream.ts
@@ -19,16 +19,63 @@ const POLL_MS = 2000;
 // Vercel kills long functions; close cleanly and let EventSource reconnect.
 const MAX_STREAM_MS = 50_000;
 
-// A killed database can leave the socket half-open, so the driver waits on a
-// query that will never answer. Bound every tick: a stalled stream that stays
-// open is worse than a closed one, because the client keeps trusting it.
-const QUERY_TIMEOUT_MS = 5000;
+// Postgres cancels the read itself, so a blocked database returns a real error
+// and frees the pooled connection instead of leaving a statement behind. Sent
+// per transaction with SET LOCAL rather than as a pool-wide startup parameter:
+// the blast radius stays on this endpoint and it survives a transaction-pooling
+// proxy, which can reject unknown startup parameters.
+const QUERY_TIMEOUT_MS = 4000;
+
+// Prisma aborts a transaction on its own clock too, and that path reports an
+// expired transaction without Postgres ever cancelling the statement. Keep it
+// strictly slower so the database is always the one that gives up first.
+const TRANSACTION_TIMEOUT_MS = 8000;
 
 // Pages Router functions read the duration off the config export, not a named
 // `maxDuration` export.
 export const config = { maxDuration: 60 };
 
 type Fingerprint = { tickets: number; changed: Date | null };
+
+// Every stream on this instance shares one in-flight read. Ten mentors cost one
+// query per tick instead of ten, and an unreachable database can only ever hold
+// a single query, so reconnects cannot pile them up in the pool.
+let inflight: Promise<Fingerprint> | null = null;
+
+const readFingerprint = () => {
+  inflight ??= prisma
+    .$transaction(
+      async (tx) => {
+        await tx.$executeRawUnsafe(
+          `SET LOCAL statement_timeout = ${QUERY_TIMEOUT_MS}`
+        );
+
+        // One statement, so the active event and its tickets come from the same
+        // snapshot. The `NOT EXISTS` branch mirrors /api/tickets/*, which fall
+        // back to every ticket when no event is active.
+        const [fingerprint] = await tx.$queryRaw<Fingerprint[]>`
+          WITH active AS (
+            SELECT id FROM "Event"
+            WHERE "isActive"
+            ORDER BY "createdTime" DESC
+            LIMIT 1
+          )
+          SELECT count(*)::int AS tickets, max("updatedTime") AS changed
+          FROM "Ticket"
+          WHERE "eventId" = (SELECT id FROM active)
+             OR NOT EXISTS (SELECT 1 FROM active)
+        `;
+
+        return fingerprint;
+      },
+      { timeout: TRANSACTION_TIMEOUT_MS }
+    )
+    .finally(() => {
+      inflight = null;
+    });
+
+  return inflight;
+};
 
 export default async function handler(
   req: NextApiRequest,
@@ -66,34 +113,8 @@ export default async function handler(
   let last = '';
 
   while (!disconnected.signal.aborted && Date.now() < deadline) {
-    const tick = new AbortController();
-
     try {
-      // One statement, so the active event and its tickets come from the same
-      // snapshot and each tick costs a single round trip. The `NOT EXISTS`
-      // branch mirrors /api/tickets/*, which fall back to every ticket when no
-      // event is active.
-      const query = prisma.$queryRaw<Fingerprint[]>`
-        WITH active AS (
-          SELECT id FROM "Event"
-          WHERE "isActive"
-          ORDER BY "createdTime" DESC
-          LIMIT 1
-        )
-        SELECT count(*)::int AS tickets, max("updatedTime") AS changed
-        FROM "Ticket"
-        WHERE "eventId" = (SELECT id FROM active)
-           OR NOT EXISTS (SELECT 1 FROM active)
-      `;
-
-      const [fingerprint] = await Promise.race([
-        query,
-        sleep(QUERY_TIMEOUT_MS, undefined, { signal: tick.signal }).then<never>(
-          () => {
-            throw new Error('Timed out reading ticket state');
-          }
-        ),
-      ]);
+      const fingerprint = await readFingerprint();
 
       // Count catches inserts and deletes, max(updatedTime) catches edits.
       const current = `${fingerprint.tickets}:${
@@ -110,12 +131,11 @@ export default async function handler(
       }
     } catch (error) {
       // Close the stream rather than keep it open in a broken state: a client
-      // that still holds an open connection trusts it and stops polling.
+      // that still holds an open connection trusts it and stops polling. The
+      // client reconnects, and its heartbeat watchdog covers the window where
+      // an unreachable database answers neither us nor Postgres' own timeout.
       console.error('Error reading ticket state for SSE:', error);
       break;
-    } finally {
-      // Cancel the losing timer so it cannot outlive its tick.
-      tick.abort();
     }
 
     try {

--- a/pages/api/tickets/stream.ts
+++ b/pages/api/tickets/stream.ts
@@ -1,0 +1,82 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getToken } from 'next-auth/jwt';
+import { getActiveEvent } from '../../../lib/eventHelper';
+import prisma from '../../../lib/prisma';
+
+/*
+ * GET Request: Server-Sent Events stream that pings clients whenever the
+ * ticket table changes. No ticket data is sent; clients revalidate the
+ * existing ticket endpoints, which already handle auth and filtering.
+ */
+
+// ponytail: server-side fingerprint poll instead of a pub/sub bus. This app
+// deploys to Vercel, where every request can land on a different instance, so
+// an in-process EventEmitter would miss writes and Postgres LISTEN/NOTIFY does
+// not survive a pgbouncer-pooled connection string. Swap in Redis/NOTIFY if
+// this aggregate ever shows up in DB load.
+const POLL_MS = 2000;
+
+// Vercel kills long functions; close cleanly and let EventSource reconnect.
+const MAX_STREAM_MS = 50_000;
+export const maxDuration = 60;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    return res.status(405).end();
+  }
+
+  const token = await getToken({ req });
+
+  if (!token) {
+    return res.status(401).end();
+  }
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive',
+    'X-Accel-Buffering': 'no',
+  });
+  res.write('retry: 3000\n\n');
+
+  let closed = false;
+  req.on('close', () => {
+    closed = true;
+  });
+
+  const deadline = Date.now() + MAX_STREAM_MS;
+  let last = '';
+
+  while (!closed && Date.now() < deadline) {
+    try {
+      const activeEvent = await getActiveEvent();
+      const { _count, _max } = await prisma.ticket.aggregate({
+        where: { eventId: activeEvent?.id },
+        _count: { _all: true },
+        _max: { updatedTime: true },
+      });
+
+      // Count catches inserts/deletes, max(updatedTime) catches edits.
+      const current = `${_count._all}:${_max.updatedTime?.getTime() ?? 0}`;
+
+      if (current === last) {
+        res.write(': ping\n\n');
+      } else {
+        last = current;
+        res.write(`data: ${current}\n\n`);
+      }
+    } catch (error) {
+      console.error('Error reading ticket state for SSE:', error);
+      res.write(': error\n\n');
+    }
+
+    const { promise, resolve } = Promise.withResolvers<void>();
+    setTimeout(resolve, POLL_MS);
+    await promise;
+  }
+
+  res.end();
+}


### PR DESCRIPTION
## What

Mentor and participant views polled `/api/tickets/*` and `/api/users/me` every 5s. They now subscribe to `/api/tickets/stream` (SSE) and revalidate the existing SWR caches only when the server reports a ticket change.

- `pages/api/tickets/stream.ts` — SSE endpoint. Auth-gated, GET only. Emits a `data:` frame when the ticket fingerprint (`count` + `max(updatedTime)` for the active event) changes, `: ping` otherwise, and closes at 50s so the browser reconnects before Vercel's function limit kills the connection.
- `hooks/use-ticket-stream.ts` — opens the `EventSource`, calls SWR `mutate` on `/api/tickets/*` and `/api/users/me`, returns the connection state.
- `TicketStream.tsx` / `Submit.tsx` — `refreshInterval: connected ? 0 : 5000`. Polling survives only as the fallback when the stream is down.

No ticket data travels over the stream, so the existing endpoints keep owning auth and filtering. Zero new dependencies.

## Why a fingerprint poll instead of a pub/sub bus

This app deploys to Vercel, so each request can land on a different instance and an in-process `EventEmitter` would never see writes from other instances. `DATABASE_PRISMA_URL` is a pgbouncer-pooled Neon URL, where `LISTEN`/`NOTIFY` does not work either. The stream therefore runs one small aggregate query every 2s per connection. That is strictly cheaper than every client running a joined `findMany` every 5s, and it needs no extra infrastructure. Swap in Redis or `NOTIFY` if it ever shows up in DB load.

## UI

Unchanged apart from a small chain-link icon above the mentor ticket list: green `MdLink` when the stream is live, gray `MdLinkOff` when it is not. The participant submit view has no visual change.

## Verification

Ran locally against a throwaway Postgres with the schema pushed, mentor view driven in a real browser.

- Guards: no cookie -> 401, `POST` -> 405.
- Stream frames observed while mutating rows directly in the DB:
  ```
  +0.0s "retry: 3000"
  +0.0s "data: 1:1787149577364"
  +2.0s ": ping"
  +4.0s "data: 2:1787149604139"   <- INSERT
  +8.0s "data: 2:1787149608144"   <- UPDATE (claim)
  +12.0s "data: 1:1787149577364"  <- DELETE (cancel)
  +50.1s [stream closed]
  ```
- Mentor page connected: green icon, `/api/tickets/active` fetched only when the stream signalled; no 5s polling over a 12s window. Tickets inserted straight into the DB appeared in the UI without a refresh.
- Stream aborted at the network layer: icon flips to gray, `EventSource` retries every 3s, `/api/tickets/active` polling resumes at 5s.
- DB unreachable: handler logs and writes `: error`, stream stays open, clients keep polling.
- `npx tsc --noEmit` clean for the changed files (one pre-existing `[...nextauth].ts` Prisma 7 adapter error remains on master).